### PR TITLE
Enabled opcache on Apache 5.5 image

### DIFF
--- a/5.5/apache/Dockerfile
+++ b/5.5/apache/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && apt-get install -y \
     && docker-php-ext-install mysql mysqli pdo pdo_mysql mcrypt zip intl \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install -j$(nproc) gd exif \
+    && docker-php-ext-enable opcache \
     && a2enmod rewrite \
     && a2enmod proxy_http \
     && a2enmod ssl


### PR DESCRIPTION
I've added a line in the image file to enable the opcache extension, it's already installed so just needs to be switched on.

There are a few reasons for doing so:
- More closely match our actual environment
- "Fixes" https://bugs.php.net/bug.php?id=66773 (the inclusion of the opcache module actually makes PHP adhere to the correct behaviour)
- Increase performance on development machines