### PR TITLE
Added images for PHP 7.2

### DIFF
--- a/7.2/fpm/Dockerfile
+++ b/7.2/fpm/Dockerfile
@@ -1,0 +1,16 @@
+FROM php:7.2-fpm
+
+RUN apt-get update && apt-get install -y \
+        libfreetype6-dev \
+        libjpeg62-turbo-dev \
+        libmcrypt-dev \
+        libpng-dev \
+        libicu-dev \
+        libxml2-dev \
+    && docker-php-ext-install pdo pdo_mysql \
+    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
+    && docker-php-ext-install -j$(nproc) gd exif \
+    && docker-php-ext-install intl \
+    && docker-php-ext-install opcache \
+    && docker-php-ext-install zip \
+    && docker-php-ext-install soap

--- a/7.2/fpm/dev/Dockerfile
+++ b/7.2/fpm/dev/Dockerfile
@@ -1,0 +1,4 @@
+FROM thedrum/php:7.2-fpm
+
+RUN pecl install xdebug \
+    && docker-php-ext-enable xdebug

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Supported tags and respective `Dockerfile` links
- - `7.1-fpm`, `7-fpm`, `latest` (*[7.1/fpm/Dockerfile](https://github.com/thedrum-developers/docker-php/blob/master/7.1/fpm/Dockerfile)*)
+ - `7.2-fpm`, `7-fpm`, `latest` (*[7.2/fpm/Dockerfile](https://github.com/thedrum-developers/docker-php/blob/master/7.2/fpm/Dockerfile)*)
+ - `7.2-fpm-dev` (*[7.2/fpm/dev/Dockerfile](https://github.com/thedrum-developers/docker-php/blob/master/7.2/fpm/dev/Dockerfile)*)
+ - `7.1-fpm` (*[7.1/fpm/Dockerfile](https://github.com/thedrum-developers/docker-php/blob/master/7.1/fpm/Dockerfile)*)
  - `7.1-fpm-dev` (*[7.1/fpm/dev/Dockerfile](https://github.com/thedrum-developers/docker-php/blob/master/7.1/fpm/dev/Dockerfile)*)
  - `7.0-fpm` (*[7.0/fpm/Dockerfile](https://github.com/thedrum-developers/docker-php/blob/master/7.0/fpm/Dockerfile)*)
  - `7.0-fpm-dev` (*[7.0/fpm/dev/Dockerfile](https://github.com/thedrum-developers/docker-php/blob/master/7.0/fpm/dev/Dockerfile)*)


### PR DESCRIPTION
I've added new images extending the offical PHP 7.2 FPM images.

The 7.2 image is based off of Debian Stretch which does not have `libpng12-dev`, but instead we should use just `libpng-dev` - https://github.com/docker-library/php/issues/485